### PR TITLE
BOOK-1292: Add blank line before return statements.

### DIFF
--- a/src/PhpCsFixerConfig.php
+++ b/src/PhpCsFixerConfig.php
@@ -16,6 +16,7 @@ class PhpCsFixerConfig extends Config
         $this->setRules([
             '@PSR12' => true,
             'array_syntax' => ['syntax' => 'short'],
+            'blank_line_before_statement' => ['statements' => ['return']],
             'braces_position' => [
                 'allow_single_line_anonymous_functions' => false,
                 'allow_single_line_empty_anonymous_classes' => false,


### PR DESCRIPTION
After voting adding this rule
![image](https://github.com/user-attachments/assets/928ed73a-bfab-43da-8e1c-75755eff24f8)
